### PR TITLE
Separate JClock (used with UI) and DefaultClock (used without UI)

### DIFF
--- a/src/jbotsim/Clock.java
+++ b/src/jbotsim/Clock.java
@@ -21,32 +21,32 @@ public abstract class Clock {
     /**
      * Returns the time unit of the clock, in milliseconds.
      */
-    abstract int getTimeUnit();
+    abstract public int getTimeUnit();
 
     /**
      * Sets the time unit of the clock to the specified value in millisecond.
      * @param delay The desired time unit (1 corresponds to the fastest rate)
      */
-    abstract void setTimeUnit(int delay);
+    abstract public void setTimeUnit(int delay);
 
     /**
      * Indicates whether the clock is currently running or paused.
      * @return <tt>true</tt> if running, <tt>false</tt> if paused.
      */
-    abstract boolean isRunning();
+    abstract public boolean isRunning();
 
     /**
      * Starts the clock.
      */
-    abstract void start();
+    abstract public void start();
 
     /**
      * Pauses the clock.
      */
-    abstract void pause();
+    abstract public void pause();
 
     /**
      * Resumes the clock if it was paused.
      */
-    abstract void resume();
+    abstract public void resume();
 }

--- a/src/jbotsim/ClockManager.java
+++ b/src/jbotsim/ClockManager.java
@@ -58,13 +58,16 @@ public class ClockManager{
      */
     public void setClockModel(Class<? extends Clock> clockModel) {
         boolean wasRunning = false;
-        if (clock != null && clock.isRunning()) {
-            wasRunning = true;
+        int timeUnit = 10;
+        if (clock != null) {
+            timeUnit = clock.getTimeUnit();
+            wasRunning = clock.isRunning();
             clock.pause();
         }
         try {
             Constructor<? extends Clock> c = clockModel.getConstructor(ClockManager.class);
             clock = c.newInstance(this);
+            clock.setTimeUnit(timeUnit);
             if (wasRunning)
                 clock.resume();
         } catch (Exception e) {e.printStackTrace();}
@@ -91,8 +94,8 @@ public class ClockManager{
     }
 
     /**
-     * Unregisters the specified listener. (The <tt>onClock()</tt> method of this 
-     * listener will not longer be called.) 
+     * Unregisters the specified listener. (The <tt>onClock()</tt> method of this
+     * listener will not longer be called.)
      * @param listener The listener to unregister.
      */
     public void removeClockListener(ClockListener listener){

--- a/src/jbotsim/ui/JClock.java
+++ b/src/jbotsim/ui/JClock.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of JBotSim.
+ *
+ *    JBotSim is free software: you can redistribute it and/or modify it
+ *    under the terms of the GNU Lesser General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Authors:
+ *    Arnaud Casteigts        <arnaud.casteigts@labri.fr>
+ */
+package jbotsim.ui;
+
+import jbotsim.ClockManager;
+import jbotsim.Clock;
+
+import javax.swing.Timer;
+
+public class JClock extends Clock {
+    Timer timer;
+
+    public JClock(ClockManager manager) {
+        super(manager);
+        timer = new Timer(10, e -> manager.onClock());
+    }
+
+    /**
+     * Returns the time unit of the clock, in milliseconds.
+     */
+    @Override
+    public int getTimeUnit(){
+        return timer.getDelay();
+    }
+
+    /**
+     * Sets the time unit of the clock to the specified value in millisecond.
+     * @param delay The desired time unit (1 corresponds to the fastest rate)
+     */
+    @Override
+    public void setTimeUnit(int delay){
+        timer.setDelay(delay);
+    }
+
+    /**
+     * Indicates whether the clock is currently running or paused.
+     * @return <tt>true</tt> if running, <tt>false</tt> if paused.
+     */
+    @Override
+    public boolean isRunning(){
+        return timer.isRunning();
+    }
+
+    /**
+     * Starts the clock.
+     */
+    @Override
+    public void start(){
+        timer.start();
+    }
+
+    /**
+     * Pauses the clock.
+     */
+    @Override
+    public void pause(){
+        timer.stop();
+    }
+
+    /**
+     * Resumes the clock if it was paused.
+     */
+    @Override
+    public void resume(){
+        timer.start();
+    }
+}

--- a/src/jbotsim/ui/JViewer.java
+++ b/src/jbotsim/ui/JViewer.java
@@ -24,9 +24,9 @@ import jbotsim.Topology;
 import jbotsimx.format.tikz.Tikz;
 
 /**
- * The viewer includes a central jtopology which will draw the attached 
+ * The viewer includes a central jtopology which will draw the attached
  * topology and offer interaction, as well as contextual commands to add or
- * remove a communication range or sensing range tuners (slider bars), or to 
+ * remove a communication range or sensing range tuners (slider bars), or to
  * pause/resume the system clock.
  */
 public class JViewer implements CommandListener, ChangeListener{
@@ -47,9 +47,9 @@ public class JViewer implements CommandListener, ChangeListener{
     /**
      * Creates a viewer for the specified topology. If <tt>selfContained</tt>
      * is <tt>true</tt>, a new window will be created to contain the viewer
-     * (similarly to <tt>JViewer(Topology)</tt>). If it is <tt>false</tt>, 
+     * (similarly to <tt>JViewer(Topology)</tt>). If it is <tt>false</tt>,
      * no window will be created and the viewer can be subsequently
-     * integrated to another swing container (e.g. another <tt>JFrame</tt> 
+     * integrated to another swing container (e.g. another <tt>JFrame</tt>
      * or a <tt>JApplet</tt>).
      * @param topo The topology to be drawn and/or manipulated.
      * @param selfContained Set this to false to avoid creating a JFrame
@@ -66,11 +66,11 @@ public class JViewer implements CommandListener, ChangeListener{
         this(jtopo, true);
     }
     /**
-     * Creates a viewer encapsulating the specified jtopology. If 
-     * <tt>selfContained</tt> is <tt>true</tt>, a new window will be created 
-     * to contain the viewer (similarly to <tt>JViewer(Topology)</tt>). If it 
-     * is <tt>false</tt>, no window will be created and the viewer can be 
-     * subsequently integrated to another swing container (e.g. another 
+     * Creates a viewer encapsulating the specified jtopology. If
+     * <tt>selfContained</tt> is <tt>true</tt>, a new window will be created
+     * to contain the viewer (similarly to <tt>JViewer(Topology)</tt>). If it
+     * is <tt>false</tt>, no window will be created and the viewer can be
+     * subsequently integrated to another swing container (e.g. another
      * <tt>JFrame</tt> or a <tt>JApplet</tt>).
      * @param jtopo The JTopology to be encapsulated.
      * @param windowed Set this to false to avoid creating a JFrame
@@ -96,13 +96,14 @@ public class JViewer implements CommandListener, ChangeListener{
                 public void componentResized(ComponentEvent e) {
                     jtp.topo.setDimensions(jtp.getWidth(), jtp.getHeight());
                 }
-            });        
+            });
         }
         slideBar.addChangeListener(this);
+        jtopo.topo.setClockModel(JClock.class);
     }
     /**
-     * Returns the jtopology attached to this viewer. Obtaining the reference 
-     * can be useful for example to add or remove action commands or action 
+     * Returns the jtopology attached to this viewer. Obtaining the reference
+     * can be useful for example to add or remove action commands or action
      * listeners to the jtopology.
      * @return The jtopology reference.
      */

--- a/src/jbotsim/ui/JViewer.java
+++ b/src/jbotsim/ui/JViewer.java
@@ -78,20 +78,20 @@ public class JViewer implements CommandListener, ChangeListener{
      */
     public JViewer(JTopology jtopo, boolean windowed){
         jtp=jtopo;
-           jtp.addCommand("Set communication range");
-           jtp.addCommand("Set sensing range");
-           jtp.addCommand("Set clock speed");
+        jtp.addCommand("Set communication range");
+        jtp.addCommand("Set sensing range");
+        jtp.addCommand("Set clock speed");
         jtp.addCommand("Pause or resume execution");
         jtp.addCommand("Execute a single step");
         jtp.addCommand("Restart nodes");
         jtp.addCommand("Export topology");
-           jtp.addCommandListener(this);
+        jtp.addCommandListener(this);
         if (windowed){ // This JViewer creates its own window
-               window=new JFrame();
-               window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-               window.add(jtp);
+            window=new JFrame();
+            window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            window.add(jtp);
             window.pack();
-               window.setVisible(true);
+            window.setVisible(true);
             window.addComponentListener(new ComponentAdapter() {
                 public void componentResized(ComponentEvent e) {
                     jtp.topo.setDimensions(jtp.getWidth(), jtp.getHeight());


### PR DESCRIPTION
Main changes :
* moved DefaultClock to JClock
* new DefaultClock using util Timer/TimerTask so that swing is not necessary anymore.

Other changes:
* I added public for all abstract methods of Clock
* ClockManager, when changing the clockModel, set the timeunit of the new Clock to match the timeunit of the previous Clock
* few cosmetic changes