### PR TITLE
correction bug lié aux IDs des noeuds

### DIFF
--- a/src/jbotsim/Topology.java
+++ b/src/jbotsim/Topology.java
@@ -51,7 +51,7 @@ public class Topology extends _Properties implements ClockListener {
     ArrayList<Node> toBeUpdated = new ArrayList<>();
     private boolean step = false;
     private boolean isStarted = false;
-    private int maxID = 0;
+    private int nextID = 0;
 
     public enum RefreshMode {CLOCKBASED, EVENTBASED}
 
@@ -415,6 +415,7 @@ public class Topology extends _Properties implements ClockListener {
     public void clear() {
         while (!nodes.isEmpty())
             removeNode(nodes.get(nodes.size() - 1));
+        nextID = 0;
     }
 
     /**
@@ -488,7 +489,7 @@ public class Topology extends _Properties implements ClockListener {
         if (isWirelessEnabled == false)
             n.disableWireless();
         if (n.getID() == -1)
-            n.setID(maxID++);
+            n.setID(nextID++);
         nodes.add(n);
         n.topo = this;
         notifyNodeAdded(n);

--- a/src/jbotsim/Topology.java
+++ b/src/jbotsim/Topology.java
@@ -51,6 +51,7 @@ public class Topology extends _Properties implements ClockListener {
     ArrayList<Node> toBeUpdated = new ArrayList<>();
     private boolean step = false;
     private boolean isStarted = false;
+    private int maxID = 0;
 
     public enum RefreshMode {CLOCKBASED, EVENTBASED}
 
@@ -487,7 +488,7 @@ public class Topology extends _Properties implements ClockListener {
         if (isWirelessEnabled == false)
             n.disableWireless();
         if (n.getID() == -1)
-            n.setID(nodes.size());
+            n.setID(maxID++);
         nodes.add(n);
         n.topo = this;
         notifyNodeAdded(n);


### PR DESCRIPTION
Une duplication d'ID de nœud se créait à chaque suppression puis ajout de nœuds.
Cela était provoqué par la définition de l'ID qui était dépendant de la taille de la liste de nœud.

Proposition: Un compteur qui augmente à chaque ajout de nœud.